### PR TITLE
Add plugin to export R1 LPF and U2 history from open ODBs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 ## 安装
 
 1. 将 `plugins/extract_r1_history.py` 复制到 Abaqus 插件目录（例如 `CAE/plugins`）或其它可被 Abaqus 插件搜索路径访问的位置。
-2. 重新启动 Abaqus/CAE，或在插件管理器中加载该脚本。
+2. 该脚本依赖 Abaqus/CAE 的 GUI 环境，仅能在 Abaqus/CAE 中加载与运行；使用系统 Python 直接执行会提示错误信息。
+3. 重新启动 Abaqus/CAE，或在插件管理器中加载该脚本。
 
 ## 使用方法
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# AbaqusODBriks
+# Abaqus ODB R1 历程提取插件
+
+该仓库包含一个适用于 Abaqus/CAE 2022 的插件脚本，用于批量提取已打开 ODB 文件中集合 `R1` 的 LPF 与 U2 历程数据。
+
+## 安装
+
+1. 将 `plugins/extract_r1_history.py` 复制到 Abaqus 插件目录（例如 `CAE/plugins`）或其它可被 Abaqus 插件搜索路径访问的位置。
+2. 重新启动 Abaqus/CAE，或在插件管理器中加载该脚本。
+
+## 使用方法
+
+1. 在 Abaqus/CAE 中打开一个或多个包含 `R1` 几何集，并且该集合已经定义了 LPF 与 U2 历程输出的 ODB 文件。
+2. 在 Visualization 模块中，通过菜单 **Plug-ins → AbaqusODBriks → 提取 R1 历程数据...** 启动插件。
+3. 弹出的对话框会列出当前已打开的所有 ODB 文件，并提供一个文本框让你指定导出 CSV 文件的路径（默认位于 Abaqus 的默认保存目录）。
+4. 点击 **OK** 之后，插件会遍历每个 ODB，检索所有包含 `R1` 集合且同时包含 `LPF` 与 `U2` 历程输出的步骤，将其组合为单个 CSV 文件。
+
+导出的 CSV 文件包含以下列：
+
+| 列名 | 含义 |
+| ---- | ---- |
+| `ODB` | ODB 文件名 |
+| `Step` | 历程所在的步骤名称 |
+| `History Region` | 匹配的历程输出区域名称 |
+| `Index` | 历程点在对应区域内的序号 |
+| `FrameValue` | 历程点的时间/步长/弧长标量值 |
+| `LPF` | 对应点的弧长法 Load Proportionality Factor 值 |
+| `U2` | 对应点的 U2 位移值 |
+
+如果未检测到任何符合条件的历程数据，插件会在消息区提示相关信息。

--- a/plugins/extract_r1_history.py
+++ b/plugins/extract_r1_history.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+"""Abaqus plugin for extracting R1 history data across open ODB files."""
+
+import csv
+import os
+import sys
+
+from abaqus import session
+from abaqusGui import (
+    AFXApp,
+    AFXDataDialog,
+    AFXForm,
+    AFXMode,
+    AFXStringKeyword,
+    AFXTextField,
+    FXGroupBox,
+    FXHorizontalFrame,
+    FXLabel,
+    FXList,
+    FXVerticalFrame,
+    FRAME_GROOVE,
+    FRAME_SUNKEN,
+    FRAME_THICK,
+    LAYOUT_FILL_X,
+    LAYOUT_FILL_Y,
+    LISTBOX_NORMAL,
+    getAFXApp,
+)
+
+
+def _is_r1_region(region_name):
+    """Return True when *region_name* corresponds to the target set R1."""
+
+    tokens = region_name.replace("/", " ").split()
+    for token in tokens:
+        if token.upper() == "R1":
+            return True
+    return False
+
+
+def _safe_makedirs(path):
+    if path and not os.path.exists(path):
+        os.makedirs(path)
+
+
+class ExtractR1HistoryForm(AFXForm):
+    """Plugin form that coordinates the dialog and extraction logic."""
+
+    def __init__(self, owner):
+        AFXForm.__init__(self, owner)
+
+        if hasattr(session, "defaultSavePath"):
+            default_dir = session.defaultSavePath
+        else:
+            default_dir = os.getcwd()
+        default_path = os.path.join(default_dir, "r1_history.csv")
+
+        self.output_path_kw = AFXStringKeyword(self, "output_path", True, default_path)
+
+    def getFirstDialog(self):
+        return ExtractR1HistoryDialog(self)
+
+    def doOkAction(self):
+        app = getAFXApp()
+        message_area = app.getAFXMainWindow().writeToMessageArea
+
+        odbs = self._get_open_odbs()
+        if not odbs:
+            message_area(u"未检测到已打开的 ODB 文件。请先打开一个 ODB。")
+            return
+
+        output_path = self.output_path_kw.getValue().strip()
+        if not output_path:
+            message_area(u"请提供有效的输出文件路径。")
+            return
+
+        try:
+            rows = self._gather_history_rows(odbs)
+            if len(rows) <= 1:
+                message_area(u"未找到包含 R1、LPF 和 U2 历程数据的步骤。")
+                return
+
+            _safe_makedirs(os.path.dirname(output_path))
+
+            if sys.version_info[0] < 3:
+                csv_file = open(output_path, "wb")
+            else:
+                csv_file = open(output_path, "w", newline="")
+            try:
+                writer = csv.writer(csv_file)
+                writer.writerows(rows)
+            finally:
+                csv_file.close()
+
+            message_area(u"已成功导出 R1 历程数据 → %s" % output_path)
+        except Exception as err:  # pylint: disable=broad-except
+            message_area(u"导出失败: %s" % err)
+            raise
+
+    def _get_open_odbs(self):
+        try:
+            return session.odbs
+        except Exception:  # pylint: disable=broad-except
+            return {}
+
+    def _gather_history_rows(self, odbs):
+        rows = [["ODB", "Step", "History Region", "Index", "FrameValue", "LPF", "U2"]]
+
+        sorted_items = sorted(odbs.items())
+        for odb_path, odb in sorted_items:
+            odb_name = os.path.basename(odb_path)
+            for step_name, step in odb.steps.items():
+                for region_name, region in step.historyRegions.items():
+                    if not _is_r1_region(region_name):
+                        continue
+
+                    lpf_output = region.historyOutputs.get("LPF")
+                    u2_output = region.historyOutputs.get("U2")
+                    if lpf_output is None or u2_output is None:
+                        continue
+
+                    data_pairs = zip(lpf_output.data, u2_output.data)
+                    index = 0
+                    for lpf_point, u2_point in data_pairs:
+                        frame_val, lpf_val = lpf_point
+                        _, u2_val = u2_point
+                        rows.append(
+                            [
+                                odb_name,
+                                step_name,
+                                region_name,
+                                index,
+                                frame_val,
+                                lpf_val,
+                                u2_val,
+                            ]
+                        )
+                        index += 1
+
+        return rows
+
+
+class ExtractR1HistoryDialog(AFXDataDialog):
+    """Dialog that shows open ODBs and lets the user configure the export."""
+
+    def __init__(self, form):
+        title = u"提取 R1 历程数据"
+        AFXDataDialog.__init__(self, form, title, self.OK | self.CANCEL)
+
+        self.form = form
+
+        vf = FXVerticalFrame(
+            self,
+            FRAME_THICK | FRAME_SUNKEN | LAYOUT_FILL_X | LAYOUT_FILL_Y,
+        )
+
+        FXLabel(vf, u"当前已打开的 ODB：")
+        self.odb_list = FXList(
+            vf,
+            opts=LISTBOX_NORMAL | FRAME_SUNKEN | FRAME_THICK | LAYOUT_FILL_X | LAYOUT_FILL_Y,
+        )
+        self._populate_odb_list()
+
+        group_box = FXGroupBox(
+            vf,
+            u"输出设置",
+            opts=FRAME_GROOVE | LAYOUT_FILL_X,
+        )
+        hf = FXHorizontalFrame(group_box, LAYOUT_FILL_X)
+        FXLabel(hf, u"输出 CSV：")
+        AFXTextField(hf, 40, form.output_path_kw, 0)
+
+    def show(self):
+        self._populate_odb_list()
+        AFXDataDialog.show(self)
+
+    def _populate_odb_list(self):
+        self.odb_list.clearItems()
+        odbs = self.form._get_open_odbs()
+        odb_paths = sorted(odbs.keys())
+        if odb_paths:
+            for odb_path in odb_paths:
+                self.odb_list.appendItem(odb_path)
+        else:
+            self.odb_list.appendItem(u"<未检测到 ODB>")
+
+
+def register_plugin():
+    app = getAFXApp()
+    toolset = app.getAFXMainWindow().getPluginToolset()
+
+    toolset.registerGuiMenuButton(
+        buttonText=u"提取 R1 历程数据...",
+        object=ExtractR1HistoryForm(toolset),
+        messageId=AFXMode.ID_CLICK,
+        icon=None,
+        kernelInitString="import extract_r1_history",
+        applicableModules=("Visualization",),
+        author="AbaqusODBriks",
+        description=(
+            u"提取所有已打开 ODB 文件中集合 R1 的 LPF 与 U2 历程数据，并输出为单个 CSV 文件。"
+        ),
+    )
+
+
+register_plugin()

--- a/plugins/extract_r1_history.py
+++ b/plugins/extract_r1_history.py
@@ -52,6 +52,7 @@ def _safe_makedirs(path):
         os.makedirs(path)
 
 
+if _abaqus_modules_available():
     class ExtractR1HistoryForm(AFXForm):
         """Plugin form that coordinates the dialog and extraction logic."""
 
@@ -212,7 +213,8 @@ def _safe_makedirs(path):
         )
 
 
-    register_plugin()
+    if __name__ == "__main__":
+        register_plugin()
 else:
     def register_plugin():
         raise RuntimeError(u"该插件只能在 Abaqus/CAE GUI 中使用。")

--- a/plugins/extract_r1_history.py
+++ b/plugins/extract_r1_history.py
@@ -4,28 +4,37 @@
 import csv
 import os
 import sys
+import importlib.util
 
-from abaqus import session
-from abaqusGui import (
-    AFXApp,
-    AFXDataDialog,
-    AFXForm,
-    AFXMode,
-    AFXStringKeyword,
-    AFXTextField,
-    FXGroupBox,
-    FXHorizontalFrame,
-    FXLabel,
-    FXList,
-    FXVerticalFrame,
-    FRAME_GROOVE,
-    FRAME_SUNKEN,
-    FRAME_THICK,
-    LAYOUT_FILL_X,
-    LAYOUT_FILL_Y,
-    LISTBOX_NORMAL,
-    getAFXApp,
-)
+
+def _abaqus_modules_available():
+    return (
+        importlib.util.find_spec("abaqus") is not None
+        and importlib.util.find_spec("abaqusGui") is not None
+    )
+
+
+if _abaqus_modules_available():
+    from abaqus import session
+    from abaqusGui import (
+        AFXDataDialog,
+        AFXForm,
+        AFXMode,
+        AFXStringKeyword,
+        AFXTextField,
+        FXGroupBox,
+        FXHorizontalFrame,
+        FXLabel,
+        FXList,
+        FXVerticalFrame,
+        FRAME_GROOVE,
+        FRAME_SUNKEN,
+        FRAME_THICK,
+        LAYOUT_FILL_X,
+        LAYOUT_FILL_Y,
+        LISTBOX_NORMAL,
+        getAFXApp,
+    )
 
 
 def _is_r1_region(region_name):
@@ -43,164 +52,170 @@ def _safe_makedirs(path):
         os.makedirs(path)
 
 
-class ExtractR1HistoryForm(AFXForm):
-    """Plugin form that coordinates the dialog and extraction logic."""
+    class ExtractR1HistoryForm(AFXForm):
+        """Plugin form that coordinates the dialog and extraction logic."""
 
-    def __init__(self, owner):
-        AFXForm.__init__(self, owner)
+        def __init__(self, owner):
+            AFXForm.__init__(self, owner)
 
-        if hasattr(session, "defaultSavePath"):
-            default_dir = session.defaultSavePath
-        else:
-            default_dir = os.getcwd()
-        default_path = os.path.join(default_dir, "r1_history.csv")
+            if hasattr(session, "defaultSavePath"):
+                default_dir = session.defaultSavePath
+            else:
+                default_dir = os.getcwd()
+            default_path = os.path.join(default_dir, "r1_history.csv")
 
-        self.output_path_kw = AFXStringKeyword(self, "output_path", True, default_path)
+            self.output_path_kw = AFXStringKeyword(self, "output_path", True, default_path)
 
-    def getFirstDialog(self):
-        return ExtractR1HistoryDialog(self)
+        def getFirstDialog(self):
+            return ExtractR1HistoryDialog(self)
 
-    def doOkAction(self):
-        app = getAFXApp()
-        message_area = app.getAFXMainWindow().writeToMessageArea
+        def doOkAction(self):
+            app = getAFXApp()
+            message_area = app.getAFXMainWindow().writeToMessageArea
 
-        odbs = self._get_open_odbs()
-        if not odbs:
-            message_area(u"未检测到已打开的 ODB 文件。请先打开一个 ODB。")
-            return
-
-        output_path = self.output_path_kw.getValue().strip()
-        if not output_path:
-            message_area(u"请提供有效的输出文件路径。")
-            return
-
-        try:
-            rows = self._gather_history_rows(odbs)
-            if len(rows) <= 1:
-                message_area(u"未找到包含 R1、LPF 和 U2 历程数据的步骤。")
+            odbs = self._get_open_odbs()
+            if not odbs:
+                message_area(u"未检测到已打开的 ODB 文件。请先打开一个 ODB。")
                 return
 
-            _safe_makedirs(os.path.dirname(output_path))
+            output_path = self.output_path_kw.getValue().strip()
+            if not output_path:
+                message_area(u"请提供有效的输出文件路径。")
+                return
 
-            if sys.version_info[0] < 3:
-                csv_file = open(output_path, "wb")
-            else:
-                csv_file = open(output_path, "w", newline="")
             try:
-                writer = csv.writer(csv_file)
-                writer.writerows(rows)
-            finally:
-                csv_file.close()
+                rows = self._gather_history_rows(odbs)
+                if len(rows) <= 1:
+                    message_area(u"未找到包含 R1、LPF 和 U2 历程数据的步骤。")
+                    return
 
-            message_area(u"已成功导出 R1 历程数据 → %s" % output_path)
-        except Exception as err:  # pylint: disable=broad-except
-            message_area(u"导出失败: %s" % err)
-            raise
+                _safe_makedirs(os.path.dirname(output_path))
 
-    def _get_open_odbs(self):
-        try:
-            return session.odbs
-        except Exception:  # pylint: disable=broad-except
-            return {}
+                if sys.version_info[0] < 3:
+                    csv_file = open(output_path, "wb")
+                else:
+                    csv_file = open(output_path, "w", newline="")
+                try:
+                    writer = csv.writer(csv_file)
+                    writer.writerows(rows)
+                finally:
+                    csv_file.close()
 
-    def _gather_history_rows(self, odbs):
-        rows = [["ODB", "Step", "History Region", "Index", "FrameValue", "LPF", "U2"]]
+                message_area(u"已成功导出 R1 历程数据 → %s" % output_path)
+            except Exception as err:  # pylint: disable=broad-except
+                message_area(u"导出失败: %s" % err)
+                raise
 
-        sorted_items = sorted(odbs.items())
-        for odb_path, odb in sorted_items:
-            odb_name = os.path.basename(odb_path)
-            for step_name, step in odb.steps.items():
-                for region_name, region in step.historyRegions.items():
-                    if not _is_r1_region(region_name):
-                        continue
+        def _get_open_odbs(self):
+            try:
+                return session.odbs
+            except Exception:  # pylint: disable=broad-except
+                return {}
 
-                    lpf_output = region.historyOutputs.get("LPF")
-                    u2_output = region.historyOutputs.get("U2")
-                    if lpf_output is None or u2_output is None:
-                        continue
+        def _gather_history_rows(self, odbs):
+            rows = [["ODB", "Step", "History Region", "Index", "FrameValue", "LPF", "U2"]]
 
-                    data_pairs = zip(lpf_output.data, u2_output.data)
-                    index = 0
-                    for lpf_point, u2_point in data_pairs:
-                        frame_val, lpf_val = lpf_point
-                        _, u2_val = u2_point
-                        rows.append(
-                            [
-                                odb_name,
-                                step_name,
-                                region_name,
-                                index,
-                                frame_val,
-                                lpf_val,
-                                u2_val,
-                            ]
-                        )
-                        index += 1
+            sorted_items = sorted(odbs.items())
+            for odb_path, odb in sorted_items:
+                odb_name = os.path.basename(odb_path)
+                for step_name, step in odb.steps.items():
+                    for region_name, region in step.historyRegions.items():
+                        if not _is_r1_region(region_name):
+                            continue
 
-        return rows
+                        lpf_output = region.historyOutputs.get("LPF")
+                        u2_output = region.historyOutputs.get("U2")
+                        if lpf_output is None or u2_output is None:
+                            continue
+
+                        data_pairs = zip(lpf_output.data, u2_output.data)
+                        index = 0
+                        for lpf_point, u2_point in data_pairs:
+                            frame_val, lpf_val = lpf_point
+                            _, u2_val = u2_point
+                            rows.append(
+                                [
+                                    odb_name,
+                                    step_name,
+                                    region_name,
+                                    index,
+                                    frame_val,
+                                    lpf_val,
+                                    u2_val,
+                                ]
+                            )
+                            index += 1
+
+            return rows
 
 
-class ExtractR1HistoryDialog(AFXDataDialog):
-    """Dialog that shows open ODBs and lets the user configure the export."""
+    class ExtractR1HistoryDialog(AFXDataDialog):
+        """Dialog that shows open ODBs and lets the user configure the export."""
 
-    def __init__(self, form):
-        title = u"提取 R1 历程数据"
-        AFXDataDialog.__init__(self, form, title, self.OK | self.CANCEL)
+        def __init__(self, form):
+            title = u"提取 R1 历程数据"
+            AFXDataDialog.__init__(self, form, title, self.OK | self.CANCEL)
 
-        self.form = form
+            self.form = form
 
-        vf = FXVerticalFrame(
-            self,
-            FRAME_THICK | FRAME_SUNKEN | LAYOUT_FILL_X | LAYOUT_FILL_Y,
+            vf = FXVerticalFrame(
+                self,
+                FRAME_THICK | FRAME_SUNKEN | LAYOUT_FILL_X | LAYOUT_FILL_Y,
+            )
+
+            FXLabel(vf, u"当前已打开的 ODB：")
+            self.odb_list = FXList(
+                vf,
+                opts=LISTBOX_NORMAL | FRAME_SUNKEN | FRAME_THICK | LAYOUT_FILL_X | LAYOUT_FILL_Y,
+            )
+            self._populate_odb_list()
+
+            group_box = FXGroupBox(
+                vf,
+                u"输出设置",
+                opts=FRAME_GROOVE | LAYOUT_FILL_X,
+            )
+            hf = FXHorizontalFrame(group_box, LAYOUT_FILL_X)
+            FXLabel(hf, u"输出 CSV：")
+            AFXTextField(hf, 40, form.output_path_kw, 0)
+
+        def show(self):
+            self._populate_odb_list()
+            AFXDataDialog.show(self)
+
+        def _populate_odb_list(self):
+            self.odb_list.clearItems()
+            odbs = self.form._get_open_odbs()
+            odb_paths = sorted(odbs.keys())
+            if odb_paths:
+                for odb_path in odb_paths:
+                    self.odb_list.appendItem(odb_path)
+            else:
+                self.odb_list.appendItem(u"<未检测到 ODB>")
+
+
+    def register_plugin():
+        app = getAFXApp()
+        toolset = app.getAFXMainWindow().getPluginToolset()
+
+        toolset.registerGuiMenuButton(
+            buttonText=u"提取 R1 历程数据...",
+            object=ExtractR1HistoryForm(toolset),
+            messageId=AFXMode.ID_CLICK,
+            icon=None,
+            kernelInitString="import extract_r1_history",
+            applicableModules=("Visualization",),
+            author="AbaqusODBriks",
+            description=(
+                u"提取所有已打开 ODB 文件中集合 R1 的 LPF 与 U2 历程数据，并输出为单个 CSV 文件。"
+            ),
         )
 
-        FXLabel(vf, u"当前已打开的 ODB：")
-        self.odb_list = FXList(
-            vf,
-            opts=LISTBOX_NORMAL | FRAME_SUNKEN | FRAME_THICK | LAYOUT_FILL_X | LAYOUT_FILL_Y,
-        )
-        self._populate_odb_list()
 
-        group_box = FXGroupBox(
-            vf,
-            u"输出设置",
-            opts=FRAME_GROOVE | LAYOUT_FILL_X,
-        )
-        hf = FXHorizontalFrame(group_box, LAYOUT_FILL_X)
-        FXLabel(hf, u"输出 CSV：")
-        AFXTextField(hf, 40, form.output_path_kw, 0)
+    register_plugin()
+else:
+    def register_plugin():
+        raise RuntimeError(u"该插件只能在 Abaqus/CAE GUI 中使用。")
 
-    def show(self):
-        self._populate_odb_list()
-        AFXDataDialog.show(self)
-
-    def _populate_odb_list(self):
-        self.odb_list.clearItems()
-        odbs = self.form._get_open_odbs()
-        odb_paths = sorted(odbs.keys())
-        if odb_paths:
-            for odb_path in odb_paths:
-                self.odb_list.appendItem(odb_path)
-        else:
-            self.odb_list.appendItem(u"<未检测到 ODB>")
-
-
-def register_plugin():
-    app = getAFXApp()
-    toolset = app.getAFXMainWindow().getPluginToolset()
-
-    toolset.registerGuiMenuButton(
-        buttonText=u"提取 R1 历程数据...",
-        object=ExtractR1HistoryForm(toolset),
-        messageId=AFXMode.ID_CLICK,
-        icon=None,
-        kernelInitString="import extract_r1_history",
-        applicableModules=("Visualization",),
-        author="AbaqusODBriks",
-        description=(
-            u"提取所有已打开 ODB 文件中集合 R1 的 LPF 与 U2 历程数据，并输出为单个 CSV 文件。"
-        ),
-    )
-
-
-register_plugin()
+    if __name__ == "__main__":
+        sys.stderr.write(u"该插件只能在 Abaqus/CAE GUI 中使用。\n")


### PR DESCRIPTION
## Summary
- add an Abaqus/CAE plugin that enumerates open ODB files, extracts LPF and U2 history data for set R1, and writes the results to a CSV file
- document installation and usage instructions for the plugin in the README

## Testing
- not run (Abaqus environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8a4527fdc8321848658426853c710